### PR TITLE
Update configuration

### DIFF
--- a/wildfly-docker-config.sh
+++ b/wildfly-docker-config.sh
@@ -11,7 +11,7 @@ wait_for_server() {
 }
 
 echo "=> Starting WildFly server"
-$JBOSS_HOME/bin/"$JBOSS_MODE.sh" -c "$JBOSS_CONFIG" > /dev/null &
+$JBOSS_HOME/bin/$JBOSS_MODE.sh -c $JBOSS_CONFIG > /dev/null &
 
 echo "=> Waiting for the server to boot"
 wait_for_server

--- a/wildfly-docker-config.sh
+++ b/wildfly-docker-config.sh
@@ -4,20 +4,20 @@ JBOSS_CLI=$JBOSS_HOME/bin/jboss-cli.sh
 JBOSS_MODE=${1:-"standalone"}
 JBOSS_CONFIG=${2:-"$JBOSS_MODE.xml"}
 
-function wait_for_server() {
-  until $($JBOSS_CLI -c "ls /deployment" &> /dev/null); do
+wait_for_server() {
+  until ($JBOSS_CLI -c "ls /deployment" &> /dev/null); do
     sleep 1
   done
 }
 
 echo "=> Starting WildFly server"
-$JBOSS_HOME/bin/$JBOSS_MODE.sh -c $JBOSS_CONFIG > /dev/null &
+$JBOSS_HOME/bin/"$JBOSS_MODE.sh" -c "$JBOSS_CONFIG" > /dev/null &
 
 echo "=> Waiting for the server to boot"
 wait_for_server
 
 echo "=> Executing the commands"
-$JBOSS_CLI -c --file=`dirname "$0"`/commands.cli
+$JBOSS_CLI -c --file="$(dirname "$0")"/commands.cli
 
 echo "=> Shutting down WildFly"
 if [ "$JBOSS_MODE" = "standalone" ]; then

--- a/wildfly-docker-config.sh
+++ b/wildfly-docker-config.sh
@@ -5,7 +5,7 @@ JBOSS_MODE=${1:-"standalone"}
 JBOSS_CONFIG=${2:-"$JBOSS_MODE.xml"}
 
 function wait_for_server() {
-  until `$JBOSS_CLI -c "ls /deployment" &> /dev/null`; do
+  until $($JBOSS_CLI -c "ls /deployment" &> /dev/null); do
     sleep 1
   done
 }


### PR DESCRIPTION
Successfully resolved build issues and addressed minor issues in the file. Proof of the build working:

```
[+] Building 0.0s (0/0)  docker:default
[+] Building 0.6s (12/12) FINISHED                                                                                                                                                                                                                                        docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                0.0s
 => => transferring dockerfile: 377B                                                                                                                                                                                                                                                0.0s 
 => [internal] load metadata for quay.io/wildfly/wildfly:31.0.0.Final-jdk20                                                                                                                                                                                                         0.2s 
 => [internal] load .dockerignore                                                                                                                                                                                                                                                   0.0s
 => => transferring context: 273B                                                                                                                                                                                                                                                   0.0s 
 => [1/7] FROM quay.io/wildfly/wildfly:31.0.0.Final-jdk20@sha256:bed301c2f5c9fae9c8317d39194fcd17490c84271ddd586cee3216dd8ee2ccb6                                                                                                                                                   0.0s 
 => [internal] load build context                                                                                                                                                                                                                                                   0.1s 
 => => transferring context: 1.58MB                                                                                                                                                                                                                                                 0.1s 
 => CACHED [2/7] WORKDIR /opt/jboss                                                                                                                                                                                                                                                 0.0s
 => CACHED [3/7] RUN wget https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.5/postgresql-42.2.5.jar                                                                                                                                                                     0.0s 
 => CACHED [4/7] ADD wildfly-docker-config.sh /                                                                                                                                                                                                                                     0.0s 
 => CACHED [5/7] ADD commands.cli /                                                                                                                                                                                                                                                 0.0s 
 => CACHED [6/7] RUN /wildfly-docker-config.sh                                                                                                                                                                                                                                      0.0s 
 => [7/7] ADD target/*.war /opt/jboss/wildfly/standalone/deployments/                                                                                                                                                                                                               0.1s 
 => exporting to image                                                                                                                                                                                                                                                              0.1s 
 => => exporting layers                                                                                                                                                                                                                                                             0.0s 
 => => writing image sha256:a7c854f8aeb01ecdace1915673228472b1183b2b488ef0030db3c39a07d6c78a                                                                                                                                                                                        0.0s 
 => => naming to docker.io/library/jakarta-labb                                                                                                                                                                                                                                     0.0s 

View build details: docker-desktop://dashboard/build/default/default/wwhu8cqvk9qs9b4b8li1m0y7k

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview

```

References that helped solve the issue:
https://github.com/koalaman/shellcheck/wiki/SC2091
https://github.com/koalaman/shellcheck/wiki/SC2086
https://github.com/koalaman/shellcheck/wiki/SC2046

Closes #63 .